### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     name: Run tests and collect coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/file_linting.yml
+++ b/.github/workflows/file_linting.yml
@@ -1,5 +1,8 @@
 name: file_linting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/syedalimohsinbukhari/plotez/security/code-scanning/1](https://github.com/syedalimohsinbukhari/plotez/security/code-scanning/1)

In general, to fix this class of problem you add an explicit `permissions` block either at the top level of the workflow (to apply to all jobs) or within individual jobs, granting only the scopes the workflow actually needs. For typical linting workflows that only check out code and run local tools, `contents: read` is sufficient.

For this specific workflow, the job only checks out the repository, installs dependencies, and runs Python linters/formatters. It does not push changes, comment on PRs, or modify issues, so it only needs read access to repository contents. The best fix with no functional change is to add `permissions: contents: read` at the workflow root, just after the `name:` or `on:` block. This will apply to all jobs (currently just `lint`) and satisfy CodeQL by constraining `GITHUB_TOKEN` to read-only repository contents.

Concretely, edit `.github/workflows/file_linting.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `name: file_linting` and the `on:` block (or between `on:` and `jobs:`—either is valid; we’ll place it after `name:` for clarity). No additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
