### PR TITLE
Update documentation and examples with type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ make html
 
 | Item           | Status                                         |
 |----------------|------------------------------------------------|
-| Latest version | v0.3.0                                         |
+| Latest version | v0.3.2                                         |
 | Python support | 3.10 · 3.11 · 3.12                             |
 | Test coverage  | 85%+                                           |
 | Type hints     | PEP 561 compliant (`py.typed`)                 |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal list literals → tuples**: All internal calls that constructed `axis_labels=[...]` before passing to
   `plot_with_dual_axes` (in `plot_xy`, `plot_xyy`, `plot_xxy`) now use `tuple` literals, eliminating spurious
   `DeprecationWarning`s from within the library itself.
+- **Examples**: Updated all examples to use correct return types.
 
 ## [v0.3.1] - 17-May-2026
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,13 +5,45 @@ All notable changes to plotez will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 17-May-2026
+## [v0.3.2] - 20-May-2026
+
+### Fixed
+
+- **Mutable default arguments**: `data_labels`, `x_labels`, `y_labels`, `subplot_titles`, and `axis_labels`
+  parameters in `plot_xyy`, `plot_xxy`, `two_subplots`, and `plot_with_dual_axes` used bare `list` literals as
+  defaults — the classic Python mutable-default bug. All replaced with `None`; intended defaults are assigned inside
+  the function body, narrowing the type to `list[str]` immediately so downstream code has no `| None` complaints.
+  A `DeprecationWarning` is now emitted when a caller explicitly passes a mutable `list`; use a `tuple` instead.
+- **Ghost `auto_label` docstring content**: Removed all references to the non-existent `auto_label` parameter from
+  the docstrings of `plot_errorbar`, `plot_with_dual_axes`, and `plot_hist`.
+- **Dead `_auto_handler` function**: Removed from `src/plotez/backend/utilities.py`; it was defined but never called
+  anywhere in the codebase. Its sole dependency `LabelConflictWarning` import was also cleaned up from that module.
+- **Internal `tight_layout` calls**: Removed `plt.tight_layout()` from `plot_with_dual_axes` and
+  `fig.tight_layout()` from `n_plotter`. Layout management is now fully at the caller's discretion.
+
+### Changed
+
+- **Axes-only returns** (**Breaking**): All plot functions now return `Axes` (single-axis) or `tuple[Axes, Axes]`
+  (dual-axis) — never `(Figure, Axes)`. Figures are always accessible via `ax.get_figure()`.
+  `n_plotter` and `two_subplots` return a shaped `(n_rows, n_cols)` `ndarray` of `Axes` instead of
+  `(Figure, flat_ndarray)`.
+- **`subplot_title` → `subplot_titles`** (**Breaking**): The parameter in `n_plotter` and `two_subplots` has been
+  renamed from `subplot_title` (singular) to `subplot_titles` (plural) to match the `_label_sanitizer` internal
+  keyword and improve consistency.
+- **`AxesFigReturn` type alias retired**: `AxesFigReturn` in `src/plotez/typing.py` is now a deprecated alias for
+  `AxesReturn` and will be removed in a future release. `AxesReturn` is extended to
+  `Axes | tuple[Axes, Axes] | NDArray` to cover all return shapes uniformly.
+- **Internal list literals → tuples**: All internal calls that constructed `axis_labels=[...]` before passing to
+  `plot_with_dual_axes` (in `plot_xy`, `plot_xyy`, `plot_xxy`) now use `tuple` literals, eliminating spurious
+  `DeprecationWarning`s from within the library itself.
+
+## [v0.3.1] - 17-May-2026
 
 ### Fixed
 
 - **RTD build**: Updated `requirements.txt` (pinned Sphinx, `myst-parser`, and related dependencies) to resolve a ReadTheDocs build failure introduced after the `0.3.0` release
 
-## [0.3.0] - 17-May-2026
+## [v0.3.0] - 17-May-2026
 
 ### Added
 
@@ -36,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/index.rst`**: Features list updated — added "Histogram & Density Plotting" bullet; updated convenience wrappers bullet to include `hgc`; bumped coverage claim to 85%+
 - **`README.md`**: Features list updated to match `index.rst`; added "### Histogram / Density" example section; bumped Project Status version to `v0.3.0` and coverage to `85%+`
 
-## [0.2.1] - 09-Mar-2026
+## [v0.2.1] - 09-Mar-2026
 
 ### Added
 
@@ -115,7 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `README.md` referencing old `LinePlot`, `line_style`, `marker_size`, `mark_every`
 - `api.rst` stale note about ErrorPlotConfig inheriting from LinePlotConfig
 
-## [v0.1.1] 16-Feb-2026
+## [v0.1.1] - 16-Feb-2026
 
 ### Changed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -194,6 +194,12 @@ Error Handling
 Type Aliases
 ------------
 
+.. note::
+
+   ``AxesFigReturn`` is deprecated as of v0.3.2 and kept only as a backward-compatible alias
+   for ``AxesReturn``. It will be removed in a future release. Use ``AxesReturn``
+   (``Axes | tuple[Axes, Axes] | NDArray``) for all new code.
+
 .. automodule:: plotez.typing
    :members:
    :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,9 +62,8 @@ autodoc_default_options = {"members": True, "member-order": "groupwise", "undoc-
 autodoc_type_aliases = {
     "Sequence": "~collections.abc.Sequence",
     "NDArray": "~plotez.typing.NDArray",
+    "ArrayLike": "~plotez.typing.ArrayLike",
     "AxesReturn": "~plotez.typing.AxesReturn",
-    "AxesFigReturn": "~plotez.typing.AxesFigReturn",
-    # "LABEL_MGMT": "~plotez.typing.LABEL_MGMT",
     "LSE": "~plotez.typing.utilities.LSE",
 }
 autodoc_typehints_format = "short"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,8 +24,9 @@ Features
 * **Error Band Plotting**: Shaded error band support via ``plot_errorband``, ``plot_errorband_relative``, and ``ErrorBandConfig``
 * **Histogram & Density Plotting**: ``plot_hist`` and ``plot_density`` with ``HistogramConfig`` / ``hgc``
 * **Dual-Axis Support**: Easy creation of dual y-axis or dual x-axis plots
-* **Multi-Panel Layouts**: Flexible subplot arrangements with automatic labeling
+* **Multi-Panel Layouts**: Flexible subplot arrangements with automatic labeling; layout (``tight_layout``) is fully user-controlled
 * **File Integration**: Direct plotting from CSV files
+* **Axes-Only Returns**: All functions return ``Axes`` (or shaped ``ndarray`` of ``Axes`` for grid functions); the parent ``Figure`` is always accessible via ``ax.get_figure()``
 * **Extensive Customization**: Full control over plot appearance via independent config dataclasses
 * **Convenience Wrappers**: Short-form factory functions (``lpc``, ``epc``, ``ebc``, ``spc``, ``hgc``) available at top level
 * **Custom Exceptions**: Domain-specific exceptions for clear, catchable error handling
@@ -58,4 +59,4 @@ Quick Example
        ecolor='red',   # different colour for error bars
        elinewidth=1.5,
    )
-   plot_errorbar(x_sparse, y_sparse, y_err=y_err, errorbar_config=ep, auto_label=True)
+   plot_errorbar(x_sparse, y_sparse, y_err=y_err, errorbar_config=ep)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,8 +16,8 @@ Basic Plotting
 Minimal Example
 ~~~~~~~~~~~~~~~
 
-The absolute minimum code to produce a labeled plot. ``auto_label=True`` generates
-``"X"``, ``"Y"``, and ``"Plot"`` as axis and title labels automatically.
+The absolute minimum code to produce a labeled plot. Pass ``x_label``, ``y_label``,
+and ``plot_title`` for axis and title labels.
 
 .. literalinclude:: ../examples/rtd_images/RTD_E1_simple.py
    :language: python
@@ -134,12 +134,20 @@ so you can pass a single uncertainty value and let plotEZ compute the band edges
 Multi-Panel Layouts
 -------------------
 
+.. note::
+
+   Neither ``two_subplots`` nor ``n_plotter`` calls ``tight_layout`` internally.
+   Call ``axs.flat[0].get_figure().tight_layout()`` (or ``plt.tight_layout()``)
+   yourself after plotting if you want tighter spacing.
+
 Two Subplots
 ~~~~~~~~~~~~
 
 ``two_subplots`` wraps ``n_plotter`` for the common two-panel case.
-Use ``orientation='h'`` for side-by-side or ``'v'`` for stacked; ``subplot_title``
+Use ``orientation='h'`` for side-by-side or ``'v'`` for stacked; ``subplot_titles``
 labels each panel individually.
+Returns a shaped ``(1, 2)`` (horizontal) or ``(2, 1)`` (vertical) ``ndarray`` of
+``Axes``; access panels as ``axs[0, 0]`` / ``axs[0, 1]`` or use ``axs.flat[i]``.
 
 .. literalinclude:: ../examples/rtd_images/RTD_E8_two_subplots.py
    :language: python
@@ -154,6 +162,9 @@ Grid of Four
 
 ``n_plotter`` handles arbitrary N×M grids. Config parameters passed as lists
 apply per-subplot, cycling if the list is shorter than the panel count.
+The function returns a shaped ``(n_rows, n_cols)`` ``ndarray`` of ``Axes``; use
+``axs.flat[i]`` for linear indexing or ``axs[row, col]`` for 2-D access.
+The parent figure is available via ``axs.flat[0].get_figure()``.
 
 .. literalinclude:: ../examples/rtd_images/RTD_E9_grid_of_four.py
    :language: python
@@ -244,9 +255,6 @@ Exception Hierarchy
        AxisLabelError,      # axis_labels has wrong length
        TwinXDataError,      # x2_data given with use_twin_x=True
        TwinYDataError,      # y2_data given with use_twin_x=False
-
-       # Warnings
-       LabelConflictWarning # auto_label overriding user labels
    )
 
 Catching Specific Exceptions
@@ -281,28 +289,27 @@ Use base classes to catch multiple related errors:
 
    try:
        # Your plotting code here
-       plot_with_dual_axes([], [1, 2, 3], auto_label=False,
-                          axis_labels=['X', 'Y'])
+       plot_with_dual_axes([], [1, 2, 3],
+                          axis_labels=("X", "Y", ""))
    except DataError:
        print("Data-related error occurred")
    except ConfigurationError:
        print("Configuration error occurred")
 
-Filtering Warnings
-~~~~~~~~~~~~~~~~~~
+Mutable-Argument Deprecation Warning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use Python's ``warnings`` module to filter or escalate custom warnings:
+Several label parameters (``data_labels``, ``x_labels``, ``y_labels``, ``subplot_titles``,
+``axis_labels``) previously accepted mutable ``list`` defaults. Passing a plain ``list``
+for these arguments now emits a ``DeprecationWarning``; prefer an immutable ``tuple``:
 
 .. code-block:: python
 
-   import warnings
-   from plotez.backend.error_handling import LabelConflictWarning
+   from plotez import two_subplots
 
-   # Suppress label conflict warnings
-   warnings.filterwarnings('ignore', category=LabelConflictWarning)
-
-   # Or escalate them to errors
-   warnings.filterwarnings('error', category=LabelConflictWarning)
+   axs = two_subplots(x_list, y_list,
+                      x_labels=("Time (s)", "Time (s)"),   # tuple — no warning
+                      y_labels=("Amplitude", "Phase"))
 
 ----
 
@@ -363,8 +370,13 @@ Mixing with Matplotlib
 ~~~~~~~~~~~~~~~~~~~~~~
 
 All ``plotez`` functions accept an ``axis`` keyword so you can drop them
-into any existing matplotlib figure. They return the ``Axes`` object for
-further customisation.
+into any existing matplotlib figure. Return types are axes-only:
+
+* Single-axis functions → ``Axes``
+* Dual-axis functions (``plot_with_dual_axes``, ``plot_xyy``, ``plot_xxy``) → ``tuple[Axes, Axes]``
+* Grid functions (``n_plotter``, ``two_subplots``) → shaped ``(n_rows, n_cols)`` ``ndarray`` of ``Axes``
+
+The parent ``Figure`` is always accessible via ``ax.get_figure()``.
 
 .. literalinclude:: ../examples/rtd_images/RTD_E12_matplotlib_integration.py
    :language: python

--- a/examples/ex_images/README_E3_dual_y_axis.py
+++ b/examples/ex_images/README_E3_dual_y_axis.py
@@ -10,7 +10,7 @@ y1 = np.sin(x)
 y2 = np.exp(-x / 10)
 
 plot_xyy(
-    x, y1, y2, x_label="Time (s)", y1_label="Signal (V)", y2_label="Decay", data_labels=["Oscillation", "Envelope"]
+    x, y1, y2, x_label="Time (s)", y1_label="Signal (V)", y2_label="Decay", data_labels=("Oscillation", "Envelope")
 )
 
 # plt.show()

--- a/examples/rtd_images/RTD_E13_histogram.py
+++ b/examples/rtd_images/RTD_E13_histogram.py
@@ -10,7 +10,7 @@ normal_data = data[:, 1]  # second column is 'normal'
 
 h_cfg = hgc(bins=40, color="steelblue", ec="white", alpha=0.8)
 
-f, ax = plot_hist(
+ax = plot_hist(
     x_data=normal_data,
     x_label="Value",
     y_label="Counts",
@@ -19,7 +19,7 @@ f, ax = plot_hist(
     hist_config=h_cfg,
 )
 
-f.tight_layout()
+plt.tight_layout()
 
 # plt.show()
 plt.savefig("RTD_E13_histogram.png", dpi=300)

--- a/examples/rtd_images/RTD_E14_density.py
+++ b/examples/rtd_images/RTD_E14_density.py
@@ -10,7 +10,7 @@ normal_data = data[:, 1]  # second column is 'normal'
 
 h_cfg = hgc(bins=40, color="mediumpurple", ec="white", alpha=0.8)
 
-f, ax = plot_density(
+ax = plot_density(
     x_data=normal_data,
     x_label="Value",
     y_label="Density",
@@ -19,7 +19,7 @@ f, ax = plot_density(
     hist_config=h_cfg,
 )
 
-f.tight_layout()
+plt.tight_layout()
 
 # plt.show()
 plt.savefig("RTD_E14_density.png", dpi=300)

--- a/examples/rtd_images/RTD_E15_errorband_relative.py
+++ b/examples/rtd_images/RTD_E15_errorband_relative.py
@@ -13,7 +13,7 @@ y_err_upper = 0.25
 band_cfg = ebc(c="lightcoral", alpha=0.35)
 line_cfg = lpc(c="darkred", lw=2, markevery=10, marker="o")
 
-f, ax = plot_errorband_relative(
+ax = plot_errorband_relative(
     x_data=x,
     y_data=y,
     y_lower=y_err_lower,
@@ -26,7 +26,7 @@ f, ax = plot_errorband_relative(
     line_config=line_cfg,
 )
 
-f.tight_layout()
+plt.tight_layout()
 
 # plt.show()
 plt.savefig("RTD_E15_errorband_relative.png", dpi=300)

--- a/examples/rtd_images/RTD_E8_two_subplots.py
+++ b/examples/rtd_images/RTD_E8_two_subplots.py
@@ -13,9 +13,9 @@ two_subplots(
     x_data=[x, x],
     y_data=[y1, y2],
     orientation="v",  # works with both 'v' and 'vertical'
-    x_labels=["Time (s)", "Time (s)"],
-    y_labels=["Amplitude", "Amplitude"],
-    data_labels=["Sine", "Cosine"],
+    x_labels=("Time (s)", "Time (s)"),
+    y_labels=("Amplitude", "Amplitude"),
+    data_labels=("Sine", "Cosine"),
     figure_kwargs={"figsize": (6, 8)},
 )
 

--- a/src/plotez/backend/_wrappers.py
+++ b/src/plotez/backend/_wrappers.py
@@ -2,6 +2,8 @@
 
 from typing import Literal
 
+from plotez.typing import HatchStyle
+
 from .utilities import ErrorBandConfig, ErrorPlotConfig, HistogramConfig, LinePlotConfig, ScatterPlotConfig
 
 __all__ = [
@@ -20,14 +22,14 @@ __all__ = [
 
 def line_plot_configuration(
     c: str | list[str] | None = None,
-    lw: float | list[float] | None = None,
+    lw: int | float | list[int | float] | None = None,
     ls: str | list[str] | None = None,
-    alpha: float | list[float] | None = None,
+    alpha: int | float | list[int | float] | None = None,
     marker: str | list[str] | None = None,
-    ms: float | list[float] | None = None,
+    ms: int | float | list[int | float] | None = None,
     mfc: str | list[str] | None = None,
     mec: str | list[str] | None = None,
-    mew: float | list[float] | None = None,
+    mew: int | float | list[int | float] | None = None,
     **kwargs,
 ):
     """
@@ -81,7 +83,7 @@ def error_band_configuration(
     lw: float | None = None,
     ec: str | None = None,
     ls: str | None = None,
-    hatch: str | Literal["/", "\\", "|", "-", "+", "x", "o", "O", ".", "*"] | None = None,
+    hatch: HatchStyle | list[HatchStyle] | None = None,
     interpolate: bool | None = None,
     step: str | Literal["pre", "post", "mid"] | None = None,
     **kwargs,
@@ -203,8 +205,8 @@ def error_plot_configuration(
 
 def scatter_plot_configuration(
     c: str | list[str] | None = None,
-    s: float | list[float] | None = None,
-    alpha: float | list[float] | None = None,
+    s: int | float | list[int | float] | None = None,
+    alpha: int | float | list[int | float] | None = None,
     marker: str | list[str] | None = None,
     cmap: str | list[str] | None = None,
     ec: str | list[str] | None = None,

--- a/src/plotez/backend/utilities.py
+++ b/src/plotez/backend/utilities.py
@@ -21,11 +21,12 @@ __all__ = [
 
 from dataclasses import dataclass, field
 from typing import Any, Literal
-from warnings import warn
 
-from ..typing import NDArray
+import numpy as np
+
+from ..typing import ArrayLike, HatchStyle, NDArray
 from .CONSTANTS import ERROR_ATTRS, ERROR_BAND_ATTRS, HIST_ATTRS, LINE_ATTRS, SCATTER_ATTRS
-from .error_handling import AxisLabelError, EmptyDataError, LabelConflictWarning, TwinXDataError, TwinYDataError
+from .error_handling import AxisLabelError, EmptyDataError, TwinXDataError, TwinYDataError
 
 if TYPE_CHECKING:
     from ..typing import LSE
@@ -64,14 +65,14 @@ class LinePlotConfig:
     """Configuration class for line plots."""
 
     color: str | list[str] | None = None
-    linewidth: float | list[float] | None = None
+    linewidth: int | float | list[int | float] | None = None
     linestyle: str | list[str] | None = None
-    alpha: float | list[float] | None = None
+    alpha: int | float | list[int | float] | None = None
     marker: str | list[str] | None = None
-    markersize: float | list[float] | None = None
+    markersize: int | float | list[int | float] | None = None
     markerfacecolor: str | list[str] | None = None
     markeredgecolor: str | list[str] | None = None
-    markeredgewidth: float | list[float] | None = None
+    markeredgewidth: int | float | list[int | float] | None = None
 
     # For extra params - pass as dict to this field directly
     _extra: dict[str, Any] = field(default_factory=dict, repr=False)
@@ -98,12 +99,12 @@ class LinePlotConfig:
 class ErrorBandConfig:
     """Configuration class for error bands (shaded fill regions)."""
 
-    color: str | None = None
-    alpha: float = 0.25
-    linewidth: float | None = None
-    edgecolor: str | None = None
-    linestyle: str | None = None
-    hatch: str | Literal["/", "\\", "|", "-", "+", "x", "o", "O", ".", "*"] | None = None
+    color: str | list[str] | None = None
+    alpha: int | float | list[int | float] = 0.25
+    linewidth: int | float | list[int | float] | None = None
+    edgecolor: str | list[str] | None = None
+    linestyle: str | list[str] | None = None
+    hatch: HatchStyle | list[HatchStyle] | None = None
     interpolate: bool | None = None
     step: str | Literal["pre", "post", "mid"] | None = None
 
@@ -133,23 +134,23 @@ class ErrorPlotConfig:
 
     # Core signal identity
     color: str | None = None
-    linewidth: float | None = None
+    linewidth: int | float | None = None
     linestyle: str | None = None
-    alpha: float | None = None
+    alpha: int | float | None = None
 
     # Error structure (second layer of perception)
     ecolor: str | None = None
-    elinewidth: float | None = None
+    elinewidth: int | float | None = None
 
     # Markers (data discreteness)
     marker: str | None = None
-    markersize: float | None = None
+    markersize: int | float | None = None
     markerfacecolor: str | None = None
     markeredgecolor: str | None = None
 
     # Visual refinement
-    capsize: float | None = None
-    capthick: float | None = None
+    capsize: int | float | None = None
+    capthick: int | float | None = None
     errorevery: int | tuple | None = None
 
     # For extra params - pass as dict to this field directly
@@ -177,13 +178,13 @@ class ErrorPlotConfig:
 class ScatterPlotConfig:
     """Configuration class for scatter plots."""
 
-    color: str | None = None
-    s: float | None = None
-    alpha: float | None = None
-    marker: str | None = None
-    cmap: str | None = None
-    edgecolors: str | None = None
-    facecolors: str | None = None
+    color: str | list[str] | None = None
+    s: int | float | list[int | float] | None = None
+    alpha: int | float | list[int | float] | None = None
+    marker: str | list[str] | None = None
+    cmap: str | list[str] | None = None
+    edgecolors: str | list[str] | None = None
+    facecolors: str | list[str] | None = None
 
     # For extra params - pass as dict to this field directly
     _extra: dict[str, Any] = field(default_factory=dict, repr=False)
@@ -214,10 +215,10 @@ class HistogramConfig:
     density: bool | None = None
     histtype: str | None = None
     color: str | None = None
-    alpha: float | None = None
+    alpha: int | float | None = None
     edgecolor: str | None = None
     facecolor: str | None = None
-    linewidth: float | None = None
+    linewidth: int | float | None = None
     orientation: str | None = None
     cumulative: bool | None = None
     hatch: str | Literal["/", "\\", "|", "-", "+", "x", "o", "O", ".", "*"] | None = None
@@ -307,13 +308,13 @@ def split_dictionary(plot_instance: LSE) -> tuple[LSE, LSE]:
 
 
 def dual_axes_data_validation(
-    x1_data: NDArray,
-    x2_data: NDArray | None,
-    y1_data: NDArray,
-    y2_data: NDArray | None,
+    x1_data: ArrayLike,
+    x2_data: ArrayLike | None,
+    y1_data: ArrayLike,
+    y2_data: ArrayLike | None,
     use_twin_x: bool,
     axis_labels: list[str | None],
-) -> None:
+) -> tuple[NDArray, NDArray, NDArray | None, NDArray | None]:
     """
     Validate the data and parameters for dual-axes plotting.
 
@@ -350,6 +351,13 @@ def dual_axes_data_validation(
         raise AxisLabelError(
             f"axis_labels must be a list of 3 strings, not a plain string. Did you mean ['{axis_labels}']?"
         )
+
+    x1_data, y1_data = np.asarray(x1_data), np.asarray(y1_data)
+    if x2_data is not None:
+        x2_data = np.asarray(x2_data)
+    if y2_data is not None:
+        y2_data = np.asarray(y2_data)
+
     if len(axis_labels) != 3:  # noqa
         raise AxisLabelError("The axis_labels should have a length of 3.")
     if len(x1_data) == 0 or len(y1_data) == 0:
@@ -359,23 +367,4 @@ def dual_axes_data_validation(
     if not use_twin_x and y2_data is not None:
         raise TwinYDataError("Dual X-axis plot requested but 'y2_data' given.")
 
-
-def _auto_handler(
-    axis_labels: list[str] | None, x1y1_label: str | None, x1y2_label: str | None, x2y1_label: str | None
-):
-    provided_labels = []
-    if x1y1_label is not None:
-        provided_labels.append("x1y1_label")
-    if x1y2_label is not None:
-        provided_labels.append("x1y2_label")
-    if x2y1_label is not None:
-        provided_labels.append("x2y1_label")
-    if axis_labels is not None and not all(x is None for x in axis_labels):
-        provided_labels.append("axis_labels")
-
-    if provided_labels:
-        warn(
-            message=f"`auto_label=True` will override provided labels: {', '.join(provided_labels)}",
-            category=LabelConflictWarning,
-            stacklevel=2,
-        )
+    return x1_data, y1_data, x2_data, y2_data

--- a/src/plotez/plotez.py
+++ b/src/plotez/plotez.py
@@ -21,7 +21,6 @@ __all__ = [
     "plot_hist",
 ]
 
-from typing import Iterable
 from warnings import warn
 
 import matplotlib.pyplot as plt
@@ -37,7 +36,7 @@ from .backend import (
     plot_or_scatter,
 )
 from .backend.error_handling import ColumnCountError, ConfigurationError, OrientationError, ShapeError
-from .typing import Axes, AxesFigReturn, AxesReturn, NDArray
+from .typing import ArrayLike, Axes, AxesReturn, NDArray
 
 # =============================================================================
 # Error Visualization Functions
@@ -45,10 +44,10 @@ from .typing import Axes, AxesFigReturn, AxesReturn, NDArray
 
 
 def plot_errorband_relative(
-    x_data: NDArray,
-    y_data: NDArray,
-    y_lower: float | NDArray | None = None,
-    y_upper: float | NDArray | None = None,
+    x_data: ArrayLike,
+    y_data: ArrayLike,
+    y_lower: int | float | ArrayLike | None = None,
+    y_upper: int | float | ArrayLike | None = None,
     x_label: str = "X",
     y_label: str = "Y",
     plot_title: str = "XY ErrorBand",
@@ -58,7 +57,7 @@ def plot_errorband_relative(
     line_config: LinePlotConfig | dict | None = None,
     axis: Axes | None = None,
     figure_kwargs: dict | None = None,
-) -> AxesFigReturn:
+) -> Axes:
     """
     Plot a line graph with a shaded error band using relative (offset) errors.
 
@@ -108,8 +107,8 @@ def plot_errorband_relative(
 
     Returns
     -------
-    AxesFigReturn
-        The Matplotlib Axes if ``axis`` was provided, otherwise a ``(Figure, Axes)`` tuple.
+    Axes
+        The Matplotlib Axes on which the plot was drawn.
 
     Raises
     ------
@@ -139,10 +138,10 @@ def plot_errorband_relative(
 
 
 def plot_errorband(
-    x_data: NDArray,
-    y_data: NDArray,
-    y_lower: float | NDArray | None = None,
-    y_upper: float | NDArray | None = None,
+    x_data: ArrayLike,
+    y_data: ArrayLike,
+    y_lower: int | float | ArrayLike | None = None,
+    y_upper: int | float | ArrayLike | None = None,
     x_label: str = "X",
     y_label: str = "Y",
     plot_title: str = "XY ErrorBand",
@@ -152,7 +151,7 @@ def plot_errorband(
     line_config: LinePlotConfig | dict | None = None,
     axis: Axes | None = None,
     figure_kwargs: dict | None = None,
-) -> AxesFigReturn:
+) -> Axes:
     """
     Plot a line graph with a shaded error band representing uncertainty.
 
@@ -197,8 +196,8 @@ def plot_errorband(
 
     Returns
     -------
-    AxesFigReturn
-        The Matplotlib Axes if ``axis`` was provided, otherwise a ``(Figure, Axes)`` tuple.
+    Axes
+        The Matplotlib Axes on which the plot was drawn.
 
     Raises
     ------
@@ -225,7 +224,7 @@ def plot_errorband(
         if figure_kwargs:
             warn("`figure_kwargs` is ignored when `axis` is provided.", UserWarning, stacklevel=2)
     else:
-        f, ax = plt.subplots(**(figure_kwargs or {}))
+        _, ax = plt.subplots(**(figure_kwargs or {}))
 
     error_band_config = band_config.get_dict() if band_config else ErrorBandConfig().get_dict()
     if isinstance(line_config, dict):
@@ -250,17 +249,14 @@ def plot_errorband(
     ax.set_title(plot_title)
     ax.legend()
 
-    if axis:
-        return ax
-    else:
-        return f, ax  # noqa
+    return ax
 
 
 def plot_errorbar(
-    x_data: NDArray,
-    y_data: NDArray,
-    x_err: float | NDArray | None = None,
-    y_err: float | NDArray | None = None,
+    x_data: ArrayLike,
+    y_data: ArrayLike,
+    x_err: int | float | ArrayLike | None = None,
+    y_err: int | float | ArrayLike | None = None,
     x_label: str = "X",
     y_label: str = "Y",
     plot_title: str = "XY ErrorBar",
@@ -268,7 +264,7 @@ def plot_errorbar(
     errorbar_config: ErrorPlotConfig | None = None,
     axis: Axes | None = None,
     figure_kwargs: dict | None = None,
-) -> AxesFigReturn:
+) -> Axes:
     """
     Plot an error bar graph with optional error ranges, labels, and configurations.
 
@@ -290,13 +286,10 @@ def plot_errorbar(
         - 2D array (2, N): asymmetric [lower_errors, upper_errors]
     x_label :
         The label for the x-axis.
-        If `None` and `auto_label` argument is set to True, a default label "X" is used.
     y_label :
         The label for the y-axis.
-        If `None` and `auto_label` argument is set to True, a default label "Y" is used.
     plot_title :
         The title of the plot.
-        If `None` and `auto_label` argument is set to True, the default title "Error Bar Plot" is used.
     data_label :
         The label for the data points, which will appear in the plot legend.
         If `None`, the legend is not displayed.
@@ -310,8 +303,8 @@ def plot_errorbar(
 
     Returns
     -------
-    AxesFigReturn
-        The Matplotlib Axes if ``axis`` was provided, otherwise a ``(Figure, Axes)`` tuple.
+    Axes
+        The Matplotlib Axes on which the plot was drawn.
     """
     x, y = np.asarray(x_data), np.asarray(y_data)
     if x_err is not None:
@@ -324,13 +317,12 @@ def plot_errorbar(
         if y_err.ndim == 2 and y_err.shape[0] != 2:
             raise ShapeError(f"Asymmetric y_err must have shape (2, N), got {y_err.shape}")
 
-    # IDE complain hack
     if axis is not None:
         if figure_kwargs:
             warn("`figure_kwargs` is ignored when `axis` is provided.", UserWarning, stacklevel=2)
         ax = axis
     else:
-        f, ax = plt.subplots(**(figure_kwargs or {}))
+        _, ax = plt.subplots(**(figure_kwargs or {}))
 
     ebc = errorbar_config.get_dict() if errorbar_config else ErrorPlotConfig().get_dict()
     ax.errorbar(x, y, xerr=x_err, yerr=y_err, label=data_label, **ebc)
@@ -340,10 +332,7 @@ def plot_errorbar(
     ax.set_title(plot_title)
     ax.legend()
 
-    if axis:
-        return ax
-    else:
-        return f, ax  # noqa
+    return ax
 
 
 # =============================================================================
@@ -428,8 +417,8 @@ def plot_two_column_file(
 
 
 def plot_xy(
-    x_data: NDArray,
-    y_data: NDArray,
+    x_data: ArrayLike,
+    y_data: ArrayLike,
     x_label: str = "X",
     y_label: str = "Y",
     data_label: str = "XY Data",
@@ -474,7 +463,7 @@ def plot_xy(
         y1_data=y_data,
         x1y1_label=data_label,
         use_twin_x=False,
-        axis_labels=[x_label, y_label, ""],
+        axis_labels=(x_label, y_label, ""),
         plot_title=plot_title,
         is_scatter=is_scatter,
         plot_config=plot_config,
@@ -492,13 +481,13 @@ def plot_xy(
 
 
 def plot_xyy(
-    x_data: NDArray,
-    y1_data: NDArray,
-    y2_data: NDArray,
+    x_data: ArrayLike,
+    y1_data: ArrayLike,
+    y2_data: ArrayLike,
     x_label: str = "X",
     y1_label: str = r"Y$_1$",
     y2_label: str = r"Y$_2$",
-    data_labels: list[str] = [r"X vs. Y$_1$", r"X vs. Y$_2$"],  # noqa
+    data_labels: list[str] | tuple[str, ...] | None = None,  # noqa
     plot_title: str = "XYY Plot",
     is_scatter: bool = False,
     plot_config: LinePlotConfig | ScatterPlotConfig | None = None,
@@ -524,7 +513,8 @@ def plot_xyy(
     plot_title :
         The title for the plot.
     data_labels :
-        The labels for the two datasets. Default is ``(None, None)``.
+        The labels for the two datasets. Default is ``(r"X vs. Y$_1$", r"X vs. Y$_2$")``.
+        Passing a mutable ``list`` is deprecated; use a ``tuple`` instead.
     is_scatter :
         Whether to create a scatter plot (`True`) or a line plot (`False`). Default is `False`.
     plot_config :
@@ -539,14 +529,22 @@ def plot_xyy(
     tuple[Axes, Axes]
         A tuple of ``(primary_axis, secondary_axis)`` for the dual y-axis plot.
     """
+    if isinstance(data_labels, list):
+        warn(
+            "Passing a mutable `list` for `data_labels` is deprecated. Use a `tuple` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    _data_labels: list[str] = list(data_labels) if data_labels is not None else [r"X vs. Y$_1$", r"X vs. Y$_2$"]
+
     _axis = plot_with_dual_axes(
         x1_data=x_data,
         y1_data=y1_data,
         y2_data=y2_data,
-        x1y1_label=data_labels[0],
-        x1y2_label=data_labels[1],
+        x1y1_label=_data_labels[0],
+        x1y2_label=_data_labels[1],
         use_twin_x=True,
-        axis_labels=[x_label, y1_label, y2_label],
+        axis_labels=(x_label, y1_label, y2_label),
         plot_title=plot_title,
         is_scatter=is_scatter,
         plot_config=plot_config,
@@ -559,13 +557,13 @@ def plot_xyy(
 
 
 def plot_xxy(
-    x1_data: NDArray,
-    x2_data: NDArray,
-    y_data: NDArray,
+    x1_data: ArrayLike,
+    x2_data: ArrayLike,
+    y_data: ArrayLike,
     y_label: str = "Y",
     x1_label: str = r"X$_1$",
     x2_label: str = r"X$_2$",
-    data_labels: list[str] = [r"Y vs. X$_1$", r"Y vs. X$_2$"],  # noqa
+    data_labels: list[str] | tuple[str, ...] | None = None,  # noqa
     plot_title: str = "",
     is_scatter: bool = False,
     plot_config: LinePlotConfig | ScatterPlotConfig | None = None,
@@ -591,7 +589,8 @@ def plot_xxy(
     plot_title :
         The title for the plot.
     data_labels :
-        The labels for the two datasets. Default is ``(None, None)``.
+        The labels for the two datasets. Default is ``(r"Y vs. X$_1$", r"Y vs. X$_2$")``.
+        Passing a mutable ``list`` is deprecated; use a ``tuple`` instead.
     is_scatter :
         Whether to create a scatter plot (`True`) or a line plot (`False`). Default is `False`.
     plot_config :
@@ -606,10 +605,13 @@ def plot_xxy(
     tuple[Axes, Axes]
         A tuple of ``(primary_axis, secondary_axis)`` for the dual x-axis plot.
     """
-    _data_labels = []
-
-    if isinstance(data_labels, Iterable):
-        _data_labels = list(data_labels)
+    if isinstance(data_labels, list):
+        warn(
+            "Passing a mutable `list` for `data_labels` is deprecated. Use a `tuple` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    _data_labels: list[str] = list(data_labels) if data_labels is not None else [r"Y vs. X$_1$", r"Y vs. X$_2$"]
 
     _axis = plot_with_dual_axes(
         x1_data=x1_data,
@@ -618,7 +620,7 @@ def plot_xxy(
         x1y1_label=_data_labels[0],
         x2y1_label=_data_labels[1],
         use_twin_x=False,
-        axis_labels=[x1_label, y_label, x2_label],
+        axis_labels=(x1_label, y_label, x2_label),
         plot_title=plot_title,
         is_scatter=is_scatter,
         plot_config=plot_config,
@@ -631,15 +633,15 @@ def plot_xxy(
 
 
 def plot_with_dual_axes(
-    x1_data: NDArray,
-    y1_data: NDArray,
-    x2_data: NDArray | None = None,
-    y2_data: NDArray | None = None,
+    x1_data: ArrayLike,
+    y1_data: ArrayLike,
+    x2_data: ArrayLike | None = None,
+    y2_data: ArrayLike | None = None,
     x1y1_label: str = r"X$_1$ vs. Y$_1$",
     x1y2_label: str = r"X$_1$ vs. Y$_2$",
     x2y1_label: str = r"X$_2$ vs. Y$_1$",
     use_twin_x: bool = False,
-    axis_labels: list[str] = ["X", r"Y$_1$", r"Y$_2$"],  # noqa
+    axis_labels: list[str] | tuple[str, ...] | None = None,  # noqa
     plot_title: str = "DualAxesPlot",
     is_scatter: bool = False,
     plot_config: LinePlotConfig | ScatterPlotConfig | None = None,
@@ -660,22 +662,19 @@ def plot_with_dual_axes(
         Data for the secondary y-axis (used for dual y-axis plots).
     x1y1_label :
         Label for the plot of X1 vs. Y1.
-        If None, and `auto_label` is True, defaults to 'X1 vs Y1'.
     x1y2_label :
         Label for the plot of X1 vs. Y2 (when using dual Y-axes).
-        If None, and `auto_label` is True, defaults to 'X1 vs Y2'.
     x2y1_label :
         Label for the plot of X2 vs. Y1 (when using dual X-axes).
-        If None, and `auto_label` is True, defaults to 'X2 vs Y1'.
     use_twin_x :
         If True, creates a dual y-axis plot. If False, creates a dual x-axis plot.
         Default is False.
     axis_labels :
-        List of axis labels in the form [x_label, y_label1, y_label2].
-        If None, and `auto_label` is True, defaults to ['X', 'Y1', 'Y2'] or ['X1', 'Y', 'X2'].
+        List of axis labels in the form ``[x_label, y_label1, y_label2]``.
+        Defaults to ``["X", r"Y$_1$", r"Y$_2$"]`` when not provided.
+        Passing a mutable ``list`` is deprecated; use a ``tuple`` instead.
     plot_title :
         Title of the plot.
-        If None, and `auto_label` is True, defaults to 'Plot'.
     is_scatter :
         If True, creates scatter plot; otherwise, line plot. Default is False.
     plot_config :
@@ -690,13 +689,21 @@ def plot_with_dual_axes(
     tuple[Axes, Axes] or Axes
         A tuple of ``(primary_axis, secondary_axis)`` when dual axes are used, otherwise a single ``Axes``.
     """
-    dual_axes_data_validation(
+    if isinstance(axis_labels, list):
+        warn(
+            "Passing a mutable `list` for `axis_labels` is deprecated. Use a `tuple` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    _axis_labels: list[str] = list(axis_labels) if axis_labels is not None else ["X", r"Y$_1$", r"Y$_2$"]
+
+    x1_data, y1_data, x2_data, y2_data = dual_axes_data_validation(
         x1_data=x1_data,
         x2_data=x2_data,
         y1_data=y1_data,
         y2_data=y2_data,
         use_twin_x=use_twin_x,
-        axis_labels=axis_labels,
+        axis_labels=_axis_labels,
     )
 
     if axis is not None:
@@ -714,11 +721,8 @@ def plot_with_dual_axes(
 
     ax2 = None
 
-    # IDE typechecking hack because we know here that axis_labels has to be
-    axis_labels: list[str]
-
-    ax1.set_xlabel(axis_labels[0])
-    ax1.set_ylabel(axis_labels[1])
+    ax1.set_xlabel(_axis_labels[0])
+    ax1.set_ylabel(_axis_labels[1])
     if plot_title:
         ax1.set_title(plot_title)
 
@@ -733,12 +737,12 @@ def plot_with_dual_axes(
         ax2 = ax1.twinx()
         if y2_data is not None:
             plot_or_scatter(axes=ax2, scatter=is_scatter)(x1_data, y2_data, label=x1y2_label, **dict2)
-            ax2.set_ylabel(axis_labels[2])
+            ax2.set_ylabel(_axis_labels[2])
 
     elif x2_data is not None:
         ax2 = ax1.twiny()
         plot_or_scatter(axes=ax2, scatter=is_scatter)(x2_data, y1_data, label=x2y1_label, **dict2)
-        ax2.set_xlabel(axis_labels[2])
+        ax2.set_xlabel(_axis_labels[2])
 
     if x1y1_label or x1y2_label or x2y1_label:
         handles, labels = ax1.get_legend_handles_labels()
@@ -747,8 +751,6 @@ def plot_with_dual_axes(
             handles += handles2
             labels += labels2
         ax1.legend(handles, labels, loc="best")
-
-    plt.tight_layout()
 
     return (ax1, ax2) if ax2 else ax1
 
@@ -759,18 +761,18 @@ def plot_with_dual_axes(
 
 
 def two_subplots(
-    x_data: NDArray | list[NDArray],
-    y_data: NDArray | list[NDArray],
-    x_labels: list[str] = [r"X$_1$", r"X$_2$"],  # noqa
-    y_labels: list[str] = [r"Y$_1$", r"Y$_2$"],  # noqa
-    data_labels: list[str] = [r"X$_1$ vs. Y$_1$", r"X$_2$ vs. Y$_2$"],  # noqa
+    x_data: ArrayLike | list[ArrayLike],
+    y_data: ArrayLike | list[ArrayLike],
+    x_labels: list[str] | tuple[str, ...] | None = None,  # noqa
+    y_labels: list[str] | tuple[str, ...] | None = None,  # noqa
+    data_labels: list[str] | tuple[str, ...] | None = None,  # noqa
     plot_title: str = "TwoSubPlots",
-    subplot_title: list[str] = ["", ""],  # noqa
+    subplot_titles: list[str] | tuple[str, ...] | None = None,  # noqa
     orientation: str = "h",
     is_scatter: bool = False,
     plot_config: LinePlotConfig | ScatterPlotConfig | None = None,
     figure_kwargs: dict | None = None,
-) -> AxesFigReturn:
+) -> NDArray:
     """Create two subplots arranged horizontally or vertically, with optional customization.
 
     Parameters
@@ -781,14 +783,21 @@ def two_subplots(
         List containing y-axis data arrays for each subplot.
     x_labels :
         List of labels for the x-axes in each subplot.
+        Defaults to ``[r"X$_1$", r"X$_2$"]``.
+        Passing a mutable ``list`` is deprecated; use a ``tuple`` instead.
     y_labels :
         List of labels for the y-axes in each subplot.
+        Defaults to ``[r"Y$_1$", r"Y$_2$"]``.
+        Passing a mutable ``list`` is deprecated; use a ``tuple`` instead.
     data_labels :
         List of labels for the data series in each subplot.
+        Defaults to ``[r"X$_1$ vs. Y$_1$", r"X$_2$ vs. Y$_2$"]``.
+        Passing a mutable ``list`` is deprecated; use a ``tuple`` instead.
     plot_title :
         Title of the plot.
-    subplot_title :
-        Titles for the subplots, if required.
+    subplot_titles :
+        Titles for the individual subplots, if required.
+        Passing a mutable ``list`` is deprecated; use a ``tuple`` instead.
     orientation :
         Orientation of the subplots, either ``'h'`` for horizontal or ``'v'`` for vertical.
     is_scatter :
@@ -800,14 +809,32 @@ def two_subplots(
 
     Returns
     -------
-    tuple[Figure, Axes]
-        A tuple of ``(figure, axes_array)`` containing the matplotlib Figure and flattened array of Axes.
+    NDArray
+        A shaped ``(n_rows, n_cols)`` array of Matplotlib ``Axes`` objects.
 
     Raises
     ------
     OrientationError
         If ``orientation`` is not ``'h'`` or ``'v'``.
     """
+    for param, name in [
+        (x_labels, "x_labels"),
+        (y_labels, "y_labels"),
+        (data_labels, "data_labels"),
+        (subplot_titles, "subplot_titles"),
+    ]:
+        if isinstance(param, list):
+            warn(
+                f"Passing a mutable `list` for `{name}` is deprecated. Use a `tuple` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+    _x_labels: list[str] = list(x_labels) if x_labels is not None else [r"X$_1$", r"X$_2$"]
+    _y_labels: list[str] = list(y_labels) if y_labels is not None else [r"Y$_1$", r"Y$_2$"]
+    _data_labels: list[str] = list(data_labels) if data_labels is not None else [r"X$_1$ vs. Y$_1$", r"X$_2$ vs. Y$_2$"]
+    _subplot_titles: list[str] = list(subplot_titles) if subplot_titles is not None else ["", ""]
+
     if orientation in ["h", "horizontal"]:
         n_rows, n_cols = 1, 2
     elif orientation in ["v", "vertical"]:
@@ -820,11 +847,11 @@ def two_subplots(
         y_data=y_data,
         n_rows=n_rows,
         n_cols=n_cols,
-        x_labels=x_labels,
-        y_labels=y_labels,
-        data_labels=data_labels,
+        x_labels=_x_labels,
+        y_labels=_y_labels,
+        data_labels=_data_labels,
         plot_title=plot_title,
-        subplot_title=subplot_title,
+        subplot_titles=_subplot_titles,
         is_scatter=is_scatter,
         plot_config=plot_config,
         figure_kwargs=figure_kwargs,
@@ -881,19 +908,19 @@ def _label_sanitizer(
 
 
 def n_plotter(
-    x_data: NDArray | list[NDArray],
-    y_data: NDArray | list[NDArray],
+    x_data: ArrayLike | list[ArrayLike],
+    y_data: ArrayLike | list[ArrayLike],
     n_rows: int,
     n_cols: int,
     x_labels: list[str] | None = None,
     y_labels: list[str] | None = None,
     data_labels: list[str] | None = None,
     plot_title: str | None = None,
-    subplot_title: list[str] | None = None,
+    subplot_titles: list[str] | None = None,
     is_scatter: bool = False,
     plot_config: LinePlotConfig | ScatterPlotConfig | None = None,
     figure_kwargs: dict | None = None,
-) -> AxesFigReturn:
+) -> NDArray:
     """
     Plot multiple subplots in a grid with optional customization for each subplot.
 
@@ -915,8 +942,8 @@ def n_plotter(
         List of labels for the data series in each subplot.
     plot_title :
         Title of the plot.
-    subplot_title :
-        Titles for the subplots, if required.
+    subplot_titles :
+        Titles for the individual subplots, if required.
     is_scatter :
         If `True`, plots data as scatter plots; otherwise, plots as line plots.
     plot_config :
@@ -926,8 +953,8 @@ def n_plotter(
 
     Returns
     -------
-    tuple[Figure, Axes]
-        A tuple of ``(figure, axes_array)`` containing the matplotlib Figure and flattened array of Axes.
+    NDArray
+        A shaped ``(n_rows, n_cols)`` array of Matplotlib ``Axes`` objects.
     """
     sp_dict = dict(figure_kwargs) if figure_kwargs else {}
     sp_dict.pop("nrows", None)
@@ -942,7 +969,7 @@ def n_plotter(
     plot_items = plot_config.get_dict() if plot_config else LinePlotConfig().get_dict()  # type: ignore
 
     fig, axs = plt.subplots(n_rows, n_cols, **sp_dict, squeeze=False)
-    axs = axs.flatten()
+    flat_axs = axs.flatten()
 
     main_dict = [
         {
@@ -952,21 +979,21 @@ def n_plotter(
         for c in range(n_cols * n_rows)
     ]
 
-    _x_labels, _y_labels, _data_labels, _subplot_title, _plot_title = _label_sanitizer(
+    _x_labels, _y_labels, _data_labels, _subplot_titles, _plot_title = _label_sanitizer(
         n_rows=n_rows,
         n_cols=n_cols,
         x_labels=x_labels,
         y_labels=y_labels,
         data_labels=data_labels,
-        subplot_titles=subplot_title,
+        subplot_titles=subplot_titles,
         plot_title=plot_title,
     )
 
     shared_y = sp_dict.get("sharey", False)
     shared_x1 = sp_dict.get("sharex", False)
-    shared_x2 = len(axs) - int(len(axs) / n_rows if n_rows > n_cols else n_cols)
+    shared_x2 = len(flat_axs) - int(len(flat_axs) / n_rows if n_rows > n_cols else n_cols)
 
-    for index, ax, x_, y_, sp_ in zip(range(n_cols * n_rows), axs, _x_labels, _y_labels, _subplot_title):
+    for index, ax, x_, y_, sp_ in zip(range(n_cols * n_rows), flat_axs, _x_labels, _y_labels, _subplot_titles):
         label = f"{_x_labels[index]} vs {_y_labels[index]}" if _data_labels is None else _data_labels[index]
         plot_or_scatter(axes=ax, scatter=is_scatter)(x_data[index], y_data[index], label=label, **main_dict[index])
         if shared_x1:
@@ -983,13 +1010,11 @@ def n_plotter(
 
     fig.suptitle(_plot_title)
 
-    fig.tight_layout()
-
-    return fig, axs
+    return axs
 
 
 def plot_density(
-    x_data: NDArray,
+    x_data: ArrayLike,
     x_label: str = "X",
     y_label: str = "Density",
     plot_title: str = "Density Plot",
@@ -997,7 +1022,7 @@ def plot_density(
     hist_config: HistogramConfig | dict | None = None,
     axis: Axes | None = None,
     figure_kwargs: dict | None = None,
-) -> AxesFigReturn:
+) -> Axes:
     """
     Plot a density histogram based on the given data and configuration.
 
@@ -1031,8 +1056,8 @@ def plot_density(
 
     Returns
     -------
-    AxesFigReturn
-        A tuple containing the Matplotlib Axes and Figure objects used to create the plot.
+    Axes
+        The Matplotlib Axes on which the density plot was drawn.
     """
     if isinstance(hist_config, dict):
         if not hist_config.get("density"):
@@ -1056,7 +1081,7 @@ def plot_density(
 
 
 def plot_hist(
-    x_data: NDArray,
+    x_data: ArrayLike,
     x_label: str = "X",
     y_label: str = "Counts",
     plot_title: str = "Histogram",
@@ -1064,7 +1089,7 @@ def plot_hist(
     hist_config: HistogramConfig | dict | None = None,
     axis: Axes | None = None,
     figure_kwargs: dict | None = None,
-) -> AxesFigReturn:
+) -> Axes:
     """
     Plot a histogram of the data.
 
@@ -1073,11 +1098,11 @@ def plot_hist(
     x_data :
         Array or sequence of data points to be histogrammed.
     x_label :
-        Label for the x-axis. If `None`, no label will be displayed unless auto-labeling is enabled.
+        Label for the x-axis.
     y_label :
-        Label for the y-axis. If `None`, no label will be displayed unless auto-labeling is enabled.
+        Label for the y-axis.
     plot_title :
-        Title for the plot. If `None`, no title will be displayed unless auto-labeling is enabled.
+        Title for the plot.
     data_label :
         Label(s) for the data series. This is used in plot's legend generation.
     hist_config :
@@ -1089,8 +1114,8 @@ def plot_hist(
 
     Returns
     -------
-    Axes | tuple[plt.Figure, Axes]
-        Either the axis object if `axis` was provided, or a tuple of (figure, axis) if a new figure was created.
+    Axes
+        The Matplotlib Axes on which the histogram was drawn.
     """
     x = np.asarray(x_data)
     if isinstance(hist_config, dict):
@@ -1103,7 +1128,7 @@ def plot_hist(
     if axis is not None:
         ax = axis
     else:
-        f, ax = plt.subplots(**(figure_kwargs or {}))
+        _, ax = plt.subplots(**(figure_kwargs or {}))
 
     if data_label and "label" in h_config:
         raise ConfigurationError("Both `data_label` and `hist_config['label']` cannot be provided.")
@@ -1120,7 +1145,4 @@ def plot_hist(
     if data_label:
         ax.legend()
 
-    if axis:
-        return ax
-    else:
-        return f, ax  # noqa
+    return ax

--- a/src/plotez/typing.py
+++ b/src/plotez/typing.py
@@ -9,26 +9,29 @@
    * - ``NDArray``
      - Re-export of :class:`numpy.ndarray` but as a typehint – any array-like input accepted by NumPy.
    * - ``AxesReturn``
-     - ``Axes | tuple[Axes, Axes]`` – return type for single- or dual-axis plot functions.
-   * - ``AxesFigReturn``
-     - ``Axes | tuple[Figure, Axes]`` – return type for functions that may create a new figure.
-   * - ``LSE``
-     - Union of all four config classes (type-checking only):
-       ``LinePlotConfig | ScatterPlotConfig | ErrorPlotConfig | ErrorBandConfig``.
+     - ``Axes | tuple[Axes, Axes] | NDArray`` – unified return type for all plot functions.
+       Single-axis functions return ``Axes``; dual-axis functions return ``tuple[Axes, Axes]``;
+       grid functions (``n_plotter``, ``two_subplots``) return a shaped ``NDArray`` of ``Axes``.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from matplotlib.axes import Axes as _Axes
 from matplotlib.figure import Figure as _Figure
+from numpy.typing import ArrayLike as _ArrayLike
 
 NDArray = np.ndarray
+ArrayLike = _ArrayLike
 Axes = _Axes
 Figure = _Figure
 
-AxesReturn = Axes | tuple[Axes, Axes]
-AxesFigReturn = Axes | tuple[Figure, Axes]
+HatchStyle = Literal["/", "\\", "|", "-", "+", "x", "o", "O", ".", "*"]
+
+AxesReturn = Axes | tuple[Axes, Axes] | NDArray
+
+# Deprecated – kept as a backward-compatible alias; will be removed in a future release.
+AxesFigReturn = AxesReturn
 
 # LABEL_MGMT = tuple[str, str, str, str, list[str | None]]
 

--- a/src/plotez/version.py
+++ b/src/plotez/version.py
@@ -1,6 +1,6 @@
 """Created on Feb 14 21:24:07 2026."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __author__ = "Syed Ali Mohsin Bukhari"
 __email__ = "ali.mohsin@ist.edu.pk"
 __license__ = "MIT"

--- a/tests/test_density_and_relative_band.py
+++ b/tests/test_density_and_relative_band.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib.axes import Axes
-from matplotlib.figure import Figure
 
 from plotez import plot_density, plot_errorband_relative
 from plotez.backend.error_handling import ConfigurationError
@@ -38,28 +37,25 @@ class TestPlotErrorbandRelative:
         """Symmetric band: only y_upper provided, y_lower inferred."""
         x, y = xy
         result = plot_errorband_relative(x, y, y_upper=0.2)
-        assert isinstance(result, tuple)
-        fig, ax = result
-        assert isinstance(fig, Figure)
-        assert isinstance(ax, Axes)
+        assert isinstance(result, Axes)
 
     def test_lower_only(self, xy):
         """Symmetric band: only y_lower provided, y_upper inferred."""
         x, y = xy
         result = plot_errorband_relative(x, y, y_lower=0.2)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_asymmetric_band(self, xy):
         """Asymmetric offsets: both y_lower and y_upper supplied."""
         x, y = xy
         result = plot_errorband_relative(x, y, y_lower=0.1, y_upper=0.3)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_array_offsets(self, xy):
         """Array-valued offsets are handled correctly."""
         x, y = xy
         result = plot_errorband_relative(x, y, y_lower=np.full_like(y, 0.1), y_upper=np.full_like(y, 0.2))
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_no_bounds_raises(self, xy):
         """Both bounds being None must raise ConfigurationError."""
@@ -71,21 +67,21 @@ class TestPlotErrorbandRelative:
         """line=False suppresses the central line."""
         x, y = xy
         result = plot_errorband_relative(x, y, y_upper=0.2, line=False)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_with_band_config(self, xy):
         """Custom ErrorBandConfig is forwarded correctly."""
         x, y = xy
         bc = ErrorBandConfig(color="orange", alpha=0.4, hatch="//")
         result = plot_errorband_relative(x, y, y_upper=0.2, band_config=bc)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_with_line_config(self, xy):
         """Custom LinePlotConfig for the central line is forwarded correctly."""
         x, y = xy
         lc = LinePlotConfig(color="red", linewidth=2, linestyle="--")
         result = plot_errorband_relative(x, y, y_upper=0.2, line_config=lc)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_on_existing_axis(self, xy):
         """When axis is provided the same axis is returned."""
@@ -105,7 +101,7 @@ class TestPlotErrorbandRelative:
     def test_custom_labels(self, xy):
         """Axis labels and title are applied to the returned axes."""
         x, y = xy
-        _, ax = plot_errorband_relative(
+        ax = plot_errorband_relative(
             x,
             y,
             y_upper=0.2,
@@ -122,7 +118,7 @@ class TestPlotErrorbandRelative:
         """Verify that the shaded region uses y ± offset, not raw offset values."""
         x, y = xy
         offset = 0.5
-        _, ax = plot_errorband_relative(x, y, y_upper=offset)
+        ax = plot_errorband_relative(x, y, y_upper=offset)
         # fill_between collections are PolyCollections; there should be exactly one
         assert len(ax.collections) == 1
 
@@ -140,23 +136,20 @@ class TestPlotDensity:
         rng = np.random.default_rng(0)
         return rng.normal(size=200)
 
-    def test_returns_figure_and_axis(self, data):
-        """Default call returns (fig, ax)."""
+    def test_returns_axes(self, data):
+        """Default call returns Axes."""
         result = plot_density(data)
-        assert isinstance(result, tuple)
-        fig, ax = result
-        assert isinstance(fig, Figure)
-        assert isinstance(ax, Axes)
+        assert isinstance(result, Axes)
 
     def test_density_true_in_hist(self, data):
         """The y-axis label should be 'Density' confirming density=True."""
-        _, ax = plot_density(data)
+        ax = plot_density(data)
         assert ax.get_ylabel() == "Density"
 
     def test_dict_config_without_density_warns_and_sets_density(self, data):
         """Passing a dict without density=True should warn and force density."""
         with pytest.warns(UserWarning, match="density=True"):
-            _, ax = plot_density(data, hist_config={"bins": 20})
+            ax = plot_density(data, hist_config={"bins": 20})
         assert ax.get_ylabel() == "Density"
 
     def test_dict_config_with_density_true_no_warning(self, data):
@@ -165,7 +158,7 @@ class TestPlotDensity:
 
         with warnings.catch_warnings(record=True) as record:
             warnings.simplefilter("always")
-            _, ax = plot_density(data, hist_config={"bins": 20, "density": True})
+            ax = plot_density(data, hist_config={"bins": 20, "density": True})
         density_warnings = [w for w in record if "density=True" in str(w.message)]
         assert len(density_warnings) == 0
         assert ax.get_ylabel() == "Density"
@@ -175,24 +168,24 @@ class TestPlotDensity:
         from plotez import HistogramConfig
 
         hc = HistogramConfig(bins=15, density=False)
-        _, ax = plot_density(data, hist_config=hc)
+        ax = plot_density(data, hist_config=hc)
         assert ax.get_ylabel() == "Density"
 
     def test_no_config_defaults(self, data):
         """Calling with no config still produces a density plot."""
-        _, ax = plot_density(data)
+        ax = plot_density(data)
         assert ax.get_ylabel() == "Density"
 
     def test_custom_labels(self, data):
         """Axis labels and title are forwarded correctly."""
-        _, ax = plot_density(data, x_label="Value", y_label="PDF", plot_title="My Density")
+        ax = plot_density(data, x_label="Value", y_label="PDF", plot_title="My Density")
         assert ax.get_xlabel() == "Value"
         # y_label is overridden internally to 'Density' by plot_hist; check title
         assert ax.get_title() == "My Density"
 
     def test_data_label_creates_legend(self, data):
         """A data_label triggers legend creation."""
-        _, ax = plot_density(data, data_label="signal")
+        ax = plot_density(data, data_label="signal")
         assert ax.get_legend() is not None
 
     def test_on_existing_axis(self, data):
@@ -203,5 +196,5 @@ class TestPlotDensity:
 
     def test_figure_kwargs_applied(self, data):
         """figure_kwargs are forwarded to the underlying plt.subplots call."""
-        fig, _ = plot_density(data, figure_kwargs={"figsize": (10, 4)})
-        assert fig.get_size_inches().tolist() == pytest.approx([10.0, 4.0])
+        ax = plot_density(data, figure_kwargs={"figsize": (10, 4)})
+        assert ax.get_figure().get_size_inches().tolist() == pytest.approx([10.0, 4.0])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib.axes import Axes
-from matplotlib.figure import Figure
 
 from plotez import HistogramConfig, hgc
 from plotez.plotez import plot_hist
@@ -37,15 +36,11 @@ def cleanup_plots():
 class TestPlotHistReturnTypes:
     """Test return type behavior of plot_hist."""
 
-    def test_returns_figure_and_axis_by_default(self, histogram_data):
-        """Test that plot_hist returns (fig, ax) when no axis is provided."""
+    def test_returns_axes_by_default(self, histogram_data):
+        """Test that plot_hist returns an Axes when no axis is provided."""
         result = plot_hist(histogram_data)
 
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        fig, ax = result
-        assert isinstance(fig, Figure)
-        assert isinstance(ax, Axes)
+        assert isinstance(result, Axes)
 
     def test_returns_existing_axis_when_provided(self, histogram_data):
         """Test that plot_hist returns the passed axis object directly."""
@@ -56,9 +51,9 @@ class TestPlotHistReturnTypes:
 
     def test_figure_kwargs_applied_to_new_figure(self, histogram_data):
         """Test that figure_kwargs are passed through when creating a new figure."""
-        fig, ax = plot_hist(histogram_data, figure_kwargs={"figsize": (10, 4)})
+        ax = plot_hist(histogram_data, figure_kwargs={"figsize": (10, 4)})
 
-        assert fig.get_size_inches().tolist() == pytest.approx([10.0, 4.0])
+        assert ax.get_figure().get_size_inches().tolist() == pytest.approx([10.0, 4.0])
 
 
 class TestPlotHistLabels:
@@ -66,7 +61,7 @@ class TestPlotHistLabels:
 
     def test_auto_label_sets_default_axis_labels_and_title(self, histogram_data):
         """Test that auto_label=True sets X, Count, and Histogram as defaults."""
-        fig, ax = plot_hist(histogram_data)
+        ax = plot_hist(histogram_data)
 
         assert ax.get_xlabel() == "X"
         assert ax.get_ylabel() == "Counts"
@@ -74,13 +69,13 @@ class TestPlotHistLabels:
 
     def test_auto_label_with_density_sets_ylabel_to_density(self, histogram_data):
         """Test that auto_label=True sets y_label to Density when density=True."""
-        fig, ax = plot_hist(histogram_data, hist_config=hgc(density=True))
+        ax = plot_hist(histogram_data, hist_config=hgc(density=True))
 
         assert ax.get_ylabel() == "Density"
 
     def test_manual_labels_are_respected(self, histogram_data):
         """Test that explicit label arguments are applied when auto_label is off."""
-        fig, ax = plot_hist(histogram_data, x_label="Value", y_label="Count", plot_title="My Distribution")
+        ax = plot_hist(histogram_data, x_label="Value", y_label="Count", plot_title="My Distribution")
 
         assert ax.get_xlabel() == "Value"
         assert ax.get_ylabel() == "Count"
@@ -88,7 +83,7 @@ class TestPlotHistLabels:
 
     def test_auto_label_does_not_set_data_label(self, histogram_data):
         """Test that auto_label=True does not generate a legend entry."""
-        fig, ax = plot_hist(histogram_data)
+        ax = plot_hist(histogram_data)
 
         assert ax.get_legend() is None
 
@@ -98,19 +93,19 @@ class TestPlotHistLegend:
 
     def test_legend_appears_when_data_label_provided(self, histogram_data):
         """Test that a legend is created when data_label is set."""
-        fig, ax = plot_hist(histogram_data, data_label="Normal")
+        ax = plot_hist(histogram_data, data_label="Normal")
 
         assert ax.get_legend() is not None
 
     def test_legend_absent_when_data_label_is_none(self, histogram_data):
         """Test that no legend is created when data_label is None."""
-        fig, ax = plot_hist(histogram_data)
+        ax = plot_hist(histogram_data)
 
         assert ax.get_legend() is None
 
     def test_legend_label_text_matches_data_label(self, histogram_data):
         """Test that the legend entry text matches the provided data_label."""
-        fig, ax = plot_hist(histogram_data, data_label="Normal")
+        ax = plot_hist(histogram_data, data_label="Normal")
         legend = ax.get_legend()
 
         assert [t.get_text() for t in legend.get_texts()] == ["Normal"]
@@ -118,7 +113,7 @@ class TestPlotHistLegend:
     def test_multi_dataset_legend_has_correct_labels(self, multi_histogram_data):
         """Test that multi-series histograms produce the correct legend entries."""
         labels = ["Uniform", "Normal", "Exponential"]
-        fig, ax = plot_hist(multi_histogram_data, data_label=labels, hist_config=hgc(bins=15, density=True, alpha=0.6))
+        ax = plot_hist(multi_histogram_data, data_label=labels, hist_config=hgc(bins=15, density=True, alpha=0.6))
         legend = ax.get_legend()
 
         assert legend is not None
@@ -130,7 +125,7 @@ class TestPlotHistConfigInputs:
 
     def test_no_config_uses_defaults(self, histogram_data):
         """Test that omitting hist_config does not raise."""
-        fig, ax = plot_hist(histogram_data)
+        ax = plot_hist(histogram_data)
 
         assert isinstance(ax, Axes)
 
@@ -139,33 +134,33 @@ class TestPlotHistConfigInputs:
         hc = HistogramConfig(
             bins=20, density=True, histtype="stepfilled", color="steelblue", alpha=0.6, edgecolor="k", linewidth=1.2
         )
-        fig, ax = plot_hist(histogram_data, hist_config=hc)
+        ax = plot_hist(histogram_data, hist_config=hc)
 
         assert isinstance(ax, Axes)
 
     def test_accepts_hgc_wrapper(self, histogram_data):
         """Test hgc convenience wrapper is accepted."""
         hc = hgc(bins=20, density=True, histtype="stepfilled", color="steelblue", alpha=0.6, ec="k", lw=1.2)
-        fig, ax = plot_hist(histogram_data, hist_config=hc)
+        ax = plot_hist(histogram_data, hist_config=hc)
 
         assert isinstance(ax, Axes)
 
     def test_accepts_dict_with_full_keys(self, histogram_data):
         """Test plain dict with full parameter names is accepted."""
-        fig, ax = plot_hist(histogram_data, hist_config={"bins": 15, "color": "crimson"})
+        ax = plot_hist(histogram_data, hist_config={"bins": 15, "color": "crimson"})
 
         assert isinstance(ax, Axes)
 
     def test_accepts_dict_with_alias_keys(self, histogram_data):
         """Test plain dict with shorthand alias keys (c, ec, lw) is accepted."""
-        fig, ax = plot_hist(histogram_data, hist_config={"bins": 15, "c": "crimson", "ec": "black", "lw": 1.5})
+        ax = plot_hist(histogram_data, hist_config={"bins": 15, "c": "crimson", "ec": "black", "lw": 1.5})
 
         assert isinstance(ax, Axes)
 
     def test_extra_kwargs_forwarded_without_error(self, histogram_data):
         """Test that unrecognised kwargs in _extra are forwarded to matplotlib."""
         hc = hgc(bins=15, rwidth=0.8, color="salmon")
-        fig, ax = plot_hist(histogram_data, hist_config=hc)
+        ax = plot_hist(histogram_data, hist_config=hc)
 
         assert isinstance(ax, Axes)
 
@@ -177,7 +172,7 @@ class TestPlotHistHisttypes:
     def test_histtype_renders_without_error(self, histogram_data, histtype):
         """Test each histtype renders cleanly."""
         hc = hgc(bins=15, histtype=histtype, color="teal", alpha=0.7)
-        fig, ax = plot_hist(histogram_data, hist_config=hc)
+        ax = plot_hist(histogram_data, hist_config=hc)
 
         assert isinstance(ax, Axes)
 
@@ -187,19 +182,19 @@ class TestPlotHistSpecialParams:
 
     def test_log_scale_sets_y_axis_to_log(self, histogram_data):
         """Test that log=True switches the y-axis to `log` scale."""
-        fig, ax = plot_hist(histogram_data, hist_config=hgc(bins=20, log=True))
+        ax = plot_hist(histogram_data, hist_config=hgc(bins=20, log=True))
 
         assert ax.get_yscale() == "log"
 
     def test_cumulative_renders_without_error(self, histogram_data):
         """Test that cumulative=True does not raise."""
-        fig, ax = plot_hist(histogram_data, hist_config=hgc(bins=20, cumulative=True, density=True))
+        ax = plot_hist(histogram_data, hist_config=hgc(bins=20, cumulative=True, density=True))
 
         assert isinstance(ax, Axes)
 
     def test_horizontal_orientation_renders_without_error(self, histogram_data):
         """Test that orientation='horizontal' does not raise."""
-        fig, ax = plot_hist(histogram_data, hist_config=hgc(bins=15, orientation="horizontal"))
+        ax = plot_hist(histogram_data, hist_config=hgc(bins=15, orientation="horizontal"))
 
         assert isinstance(ax, Axes)
 
@@ -207,5 +202,5 @@ class TestPlotHistSpecialParams:
         """Test that the hatch parameter is not raised for supported hist types."""
         for histtype, hatch in [("bar", "//"), ("stepfilled", "xx")]:
             hc = hgc(bins=15, histtype=histtype, hatch=hatch, color="gold", edgecolor="k")
-            fig, ax = plot_hist(histogram_data, hist_config=hc)
+            ax = plot_hist(histogram_data, hist_config=hc)
             assert isinstance(ax, Axes)

--- a/tests/test_plotez.py
+++ b/tests/test_plotez.py
@@ -33,27 +33,27 @@ class TestPlotTwoColumnFile:
     def test_plot_two_column_file_basic(self, temp_csv_file):
         """Test basic file plotting."""
         result = plot_two_column_file(temp_csv_file)
-        assert isinstance(result, Axes) or isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_plot_two_column_file_with_header(self, temp_csv_file_with_header):
         """Test file plotting with header skip."""
         result = plot_two_column_file(temp_csv_file_with_header, skip_header=True)
-        assert isinstance(result, Axes) or isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_plot_two_column_file_with_labels(self, temp_csv_file):
         """Test file plotting with custom labels."""
         result = plot_two_column_file(temp_csv_file, x_label="X Axis", y_label="Y Axis", plot_title="Test Plot")
-        assert isinstance(result, Axes) or isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_plot_two_column_file_auto_label(self, temp_csv_file):
         """Test file plotting with auto-labeling."""
         result = plot_two_column_file(temp_csv_file)
-        assert isinstance(result, Axes) or isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_plot_two_column_file_scatter(self, temp_csv_file):
         """Test file plotting as a scatter plot."""
         result = plot_two_column_file(temp_csv_file, is_scatter=True)
-        assert isinstance(result, Axes) or isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_plot_two_column_file_invalid_columns(self, tmp_path):
         """Test that an invalid file raises ColumnCountError."""
@@ -150,7 +150,7 @@ class TestPlotXYY:
             x_label="X",
             y1_label="Y1",
             y2_label="Y2",
-            data_labels=["Series 1", "Series 2"],
+            data_labels=("Series 1", "Series 2"),
             plot_title="Dual Y Plot",
         )
         assert isinstance(result, tuple)
@@ -215,7 +215,7 @@ class TestPlotWithDualAxes:
             x1y1_label="Primary",
             x1y2_label="Secondary",
             use_twin_x=True,
-            axis_labels=["X", "Y1", "Y2"],
+            axis_labels=("X", "Y1", "Y2"),
             plot_title="Dual Axes Plot",
         )
         assert isinstance(result, tuple)
@@ -240,51 +240,51 @@ class TestTwoSubplots:
         x_list = [sample_x_data, sample_x_data]
         y_list = [sample_y_data, sample_y_data * 2]
 
-        fig, axs = two_subplots(x_list, y_list, orientation="h")
-        assert isinstance(fig, plt.Figure)
-        assert len(axs) == 2
+        axs = two_subplots(x_list, y_list, orientation="h")
+        assert isinstance(axs, np.ndarray)
+        assert axs.shape == (1, 2)
 
     def test_two_subplots_vertical(self, sample_x_data, sample_y_data):
         """Test two vertical subplots."""
         x_list = [sample_x_data, sample_x_data]
         y_list = [sample_y_data, sample_y_data * 2]
 
-        fig, axs = two_subplots(x_list, y_list, orientation="v")
-        assert isinstance(fig, plt.Figure)
-        assert len(axs) == 2
+        axs = two_subplots(x_list, y_list, orientation="v")
+        assert isinstance(axs, np.ndarray)
+        assert axs.shape == (2, 1)
 
     def test_two_subplots_with_labels(self, sample_x_data, sample_y_data):
         """Test subplots with custom labels."""
         x_list = [sample_x_data, sample_x_data]
         y_list = [sample_y_data, sample_y_data * 2]
 
-        fig, axs = two_subplots(
+        axs = two_subplots(
             x_list,
             y_list,
-            x_labels=["X1", "X2"],
-            y_labels=["Y1", "Y2"],
-            data_labels=["Data 1", "Data 2"],
+            x_labels=("X1", "X2"),
+            y_labels=("Y1", "Y2"),
+            data_labels=("Data 1", "Data 2"),
             plot_title="Two Plots",
-            subplot_title=["Plot 1", "Plot 2"],
+            subplot_titles=("Plot 1", "Plot 2"),
             orientation="h",
         )
-        assert isinstance(fig, plt.Figure)
+        assert isinstance(axs, np.ndarray)
 
     def test_two_subplots_auto_label(self, sample_x_data, sample_y_data):
         """Test subplots with auto labeling."""
         x_list = [sample_x_data, sample_x_data]
         y_list = [sample_y_data, sample_y_data * 2]
 
-        fig, axs = two_subplots(x_list, y_list, orientation="h")
-        assert isinstance(fig, plt.Figure)
+        axs = two_subplots(x_list, y_list, orientation="h")
+        assert isinstance(axs, np.ndarray)
 
     def test_two_subplots_scatter(self, sample_x_data, sample_y_data):
         """Test scatter subplots."""
         x_list = [sample_x_data, sample_x_data]
         y_list = [sample_y_data, sample_y_data * 2]
 
-        fig, axs = two_subplots(x_list, y_list, orientation="h", is_scatter=True)
-        assert isinstance(fig, plt.Figure)
+        axs = two_subplots(x_list, y_list, orientation="h", is_scatter=True)
+        assert isinstance(axs, np.ndarray)
 
     def test_two_subplots_invalid_orientation(self, sample_x_data, sample_y_data):
         """Test that invalid orientation raises an error."""
@@ -300,26 +300,26 @@ class TestNPlotter:
 
     def test_n_plotter_2x2(self, sample_x_data_list, sample_y_data_list):
         """Test 2x2 grid plotting."""
-        fig, axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
-        assert isinstance(fig, plt.Figure)
-        assert len(axs) == 4
+        axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
+        assert isinstance(axs, np.ndarray)
+        assert axs.shape == (2, 2)
 
     def test_n_plotter_1x3(self, sample_x_data_list, sample_y_data_list):
         """Test 1x3 grid plotting."""
-        fig, axs = n_plotter(sample_x_data_list[:3], sample_y_data_list[:3], n_rows=1, n_cols=3)
-        assert isinstance(fig, plt.Figure)
-        assert len(axs) == 3
+        axs = n_plotter(sample_x_data_list[:3], sample_y_data_list[:3], n_rows=1, n_cols=3)
+        assert isinstance(axs, np.ndarray)
+        assert axs.shape == (1, 3)
 
     def test_n_plotter_3x1(self, sample_x_data_list, sample_y_data_list):
         """Test 3x1 grid plotting."""
-        fig, axs = n_plotter(sample_x_data_list[:3], sample_y_data_list[:3], n_rows=3, n_cols=1)
-        assert isinstance(fig, plt.Figure)
-        assert len(axs) == 3
+        axs = n_plotter(sample_x_data_list[:3], sample_y_data_list[:3], n_rows=3, n_cols=1)
+        assert isinstance(axs, np.ndarray)
+        assert axs.shape == (3, 1)
 
     def test_n_plotter_auto_label(self, sample_x_data_list, sample_y_data_list):
         """Test n_plotter with auto labeling."""
-        fig, axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
-        assert isinstance(fig, plt.Figure)
+        axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
+        assert isinstance(axs, np.ndarray)
 
     def test_n_plotter_with_labels(self, sample_x_data_list, sample_y_data_list):
         """Test n_plotter with custom labels."""
@@ -328,7 +328,7 @@ class TestNPlotter:
         data_labels = ["D1", "D2", "D3", "D4"]
         subplot_titles = ["S1", "S2", "S3", "S4"]
 
-        fig, axs = n_plotter(
+        axs = n_plotter(
             sample_x_data_list,
             sample_y_data_list,
             n_rows=2,
@@ -337,47 +337,48 @@ class TestNPlotter:
             y_labels=y_labels,
             data_labels=data_labels,
             plot_title="N Plotter Test",
-            subplot_title=subplot_titles,
+            subplot_titles=subplot_titles,
         )
-        assert isinstance(fig, plt.Figure)
+        assert isinstance(axs, np.ndarray)
 
     def test_n_plotter_scatter(self, sample_x_data_list, sample_y_data_list):
         """Test n_plotter with scatter plots."""
-        fig, axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2, is_scatter=True)
-        assert isinstance(fig, plt.Figure)
+        axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2, is_scatter=True)
+        assert isinstance(axs, np.ndarray)
 
     def test_n_plotter_with_plot_dict(self, sample_x_data_list, sample_y_data_list):
         """Test n_plotter with a plot dictionary."""
         lp = LinePlotConfig(linestyle=["-", "--", "-.", ":"], color=["red", "blue", "green", "orange"])
-        fig, axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2, plot_config=lp)
-        assert isinstance(fig, plt.Figure)
+        axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2, plot_config=lp)
+        assert isinstance(axs, np.ndarray)
 
     def test_n_plotter_with_subplot_dict(self, sample_x_data_list, sample_y_data_list):
         """Test n_plotter with figure kwargs."""
-        fig, axs = n_plotter(
+        axs = n_plotter(
             sample_x_data_list,
             sample_y_data_list,
             n_rows=2,
             n_cols=2,
             figure_kwargs={"sharex": True, "sharey": True, "figsize": (12, 8)},
         )
-        assert isinstance(fig, plt.Figure)
+        assert isinstance(axs, np.ndarray)
 
     def test_n_plotter_auto_label_no_legends(self, sample_x_data_list, sample_y_data_list):
         """Test that auto_label=True does not generate legends in n_plotter."""
-        fig, axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
+        axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
         # None of the subplots should have legends
-        for ax in axs:
+        for ax in axs.flat:
             assert ax.get_legend() is None
 
     def test_n_plotter_auto_label_sets_axes_and_titles(self, sample_x_data_list, sample_y_data_list):
         """Test that auto_label=True sets axis labels and titles correctly."""
-        fig, axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
+        axs = n_plotter(sample_x_data_list, sample_y_data_list, n_rows=2, n_cols=2)
         # Check that axes have labels
-        assert axs[0].get_xlabel() == ""
-        assert axs[0].get_ylabel() == ""
-        assert axs[0].get_title() == ""
-        # Check the main plot title
+        assert axs.flat[0].get_xlabel() == ""
+        assert axs.flat[0].get_ylabel() == ""
+        assert axs.flat[0].get_title() == ""
+        # Check the main plot title via figure
+        fig = axs.flat[0].get_figure()
         assert fig.texts[0].get_text() == "" if fig.texts else True
 
 
@@ -387,32 +388,32 @@ class TestPlotErrorbar:
     def test_errorbar_basic(self, sample_x_data, sample_y_data):
         """Test basic error bar plotting without errors."""
         result = plot_errorbar(sample_x_data, sample_y_data)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_with_y_err(self, sample_x_data, sample_y_data, sample_y_err):
         """Test error bar plotting with y errors."""
         result = plot_errorbar(sample_x_data, sample_y_data, y_err=sample_y_err)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_with_x_err(self, sample_x_data, sample_y_data, sample_x_err):
         """Test error bar plotting with x errors."""
         result = plot_errorbar(sample_x_data, sample_y_data, x_err=sample_x_err)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_with_both_errors(self, sample_x_data, sample_y_data, sample_x_err, sample_y_err):
         """Test error bar plotting with both x and y errors."""
         result = plot_errorbar(sample_x_data, sample_y_data, x_err=sample_x_err, y_err=sample_y_err)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_with_scalar_errors(self, sample_x_data, sample_y_data):
         """Test error bar plotting with scalar error values."""
         result = plot_errorbar(sample_x_data, sample_y_data, x_err=0.1, y_err=0.2)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_auto_label(self, sample_x_data, sample_y_data, sample_y_err):
         """Test error bar plotting with auto labeling."""
         result = plot_errorbar(sample_x_data, sample_y_data, y_err=sample_y_err)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_with_labels(self, sample_x_data, sample_y_data, sample_y_err):
         """Test error bar plotting with custom labels."""
@@ -425,18 +426,18 @@ class TestPlotErrorbar:
             plot_title="Error Bar Test",
             data_label="Data",
         )
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_with_config(self, sample_x_data, sample_y_data, sample_y_err):
         """Test error bar plotting with ErrorPlotConfig."""
         ep = ErrorPlotConfig(capsize=5, ecolor="red", color="blue", linewidth=2)
         result = plot_errorbar(sample_x_data, sample_y_data, y_err=sample_y_err, errorbar_config=ep)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_with_figure_kwargs(self, sample_x_data, sample_y_data, sample_y_err):
         """Test error bar plotting with figure kwargs."""
         result = plot_errorbar(sample_x_data, sample_y_data, y_err=sample_y_err, figure_kwargs={"figsize": (10, 6)})
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorbar_on_existing_axis(self, sample_x_data, sample_y_data, sample_y_err):
         """Test error bar plotting on an existing axis."""
@@ -498,27 +499,27 @@ class TestPlotErrorband:
     def test_errorband_basic(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test basic error band plotting."""
         result = plot_errorband(sample_x_data, sample_y_data, sample_y_lower, sample_y_upper)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_lower_only(self, sample_x_data, sample_y_data, sample_y_lower):
         """Test the error band with the lower bound and y_data as the upper."""
         result = plot_errorband(sample_x_data, sample_y_data, y_lower=sample_y_lower, y_upper=sample_y_data)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_upper_only(self, sample_x_data, sample_y_data, sample_y_upper):
         """Test the error band with the upper bound and y_data as the lower."""
         result = plot_errorband(sample_x_data, sample_y_data, y_lower=sample_y_data, y_upper=sample_y_upper)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_scalar_bounds(self, sample_x_data, sample_y_data):
         """Test the error band with scalar bounds."""
         result = plot_errorband(sample_x_data, sample_y_data, y_lower=-0.5, y_upper=0.5)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_auto_label(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test the error band with auto labeling."""
         result = plot_errorband(sample_x_data, sample_y_data, sample_y_lower, sample_y_upper)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_with_labels(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test the error band with custom labels."""
@@ -532,31 +533,31 @@ class TestPlotErrorband:
             plot_title="Band Test",
             data_label="Series",
         )
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_no_line(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test the error band without the central line."""
         result = plot_errorband(sample_x_data, sample_y_data, sample_y_lower, sample_y_upper, line=False)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_with_band_config(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test error band with ErrorBandConfig."""
         bc = ErrorBandConfig(color="cyan", alpha=0.3, edgecolor="black", linestyle="--")
         result = plot_errorband(sample_x_data, sample_y_data, sample_y_lower, sample_y_upper, band_config=bc)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_with_line_config(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test the error band with LinePlotConfig for the central line."""
         lc = LinePlotConfig(color="gold", linestyle="--", linewidth=2)
         result = plot_errorband(sample_x_data, sample_y_data, sample_y_lower, sample_y_upper, line_config=lc)
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_with_figure_kwargs(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test error band with figure kwargs."""
         result = plot_errorband(
             sample_x_data, sample_y_data, sample_y_lower, sample_y_upper, figure_kwargs={"figsize": (10, 6)}
         )
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
     def test_errorband_on_existing_axis(self, sample_x_data, sample_y_data, sample_y_lower, sample_y_upper):
         """Test error band on an existing axis."""
@@ -578,7 +579,7 @@ class TestPlotErrorband:
             line_config=lc,
             figure_kwargs={"figsize": (12, 6)},
         )
-        assert isinstance(result, tuple)
+        assert isinstance(result, Axes)
 
 
 class TestCustomExceptions:
@@ -601,40 +602,39 @@ class TestCustomExceptions:
     def test_empty_data_error_for_empty_x_data(self):
         """Test that EmptyDataError is raised for empty x data."""
         with pytest.raises(EmptyDataError, match="Primary x or y data is empty"):
-            plot_with_dual_axes([], [1, 2, 3], axis_labels=["X", "Y1", "Y2"])
+            plot_with_dual_axes([], [1, 2, 3], axis_labels=("X", "Y1", "Y2"))
 
     def test_empty_data_error_for_empty_y_data(self):
         """Test that EmptyDataError is raised for empty y data."""
         with pytest.raises(EmptyDataError, match="Primary x or y data is empty"):
-            plot_with_dual_axes([1, 2, 3], [], axis_labels=["X", "Y1", "Y2"])
+            plot_with_dual_axes([1, 2, 3], [], axis_labels=("X", "Y1", "Y2"))
 
     def test_axis_label_error_for_too_few_labels(self, sample_x_data, sample_y_data):
         """Test that AxisLabelError is raised when axis_labels has fewer than 3 elements."""
         with pytest.raises(AxisLabelError, match="axis_labels should have a length of 3"):
-            plot_with_dual_axes(sample_x_data, sample_y_data, axis_labels=["X", "Y"])
+            plot_with_dual_axes(sample_x_data, sample_y_data, axis_labels=("X", "Y"))
 
     def test_axis_label_error_for_too_many_labels(self, sample_x_data, sample_y_data):
         """Test that AxisLabelError is raised when axis_labels has more than 3 elements."""
         with pytest.raises(AxisLabelError, match="axis_labels should have a length of 3"):
-            plot_with_dual_axes(sample_x_data, sample_y_data, axis_labels=["X", "Y1", "Y2", "Extra"])
+            plot_with_dual_axes(sample_x_data, sample_y_data, axis_labels=("X", "Y1", "Y2", "Extra"))
 
     def test_twin_x_data_error_for_x2_data_with_twin_y(self, sample_x_data, sample_y_data):
         """Test that TwinXDataError is raised when x2_data is given with use_twin_x=True."""
         with pytest.raises(TwinXDataError, match="Dual Y-axis plot requested but 'x2_data' given"):
             plot_with_dual_axes(
-                sample_x_data, sample_y_data, x2_data=sample_x_data, use_twin_x=True, axis_labels=["X", "Y1", "Y2"]
+                sample_x_data, sample_y_data, x2_data=sample_x_data, use_twin_x=True, axis_labels=("X", "Y1", "Y2")
             )
 
     def test_twin_y_data_error_for_y2_data_with_twin_x(self, sample_x_data, sample_y_data):
         """Test that TwinYDataError is raised when y2_data is given with use_twin_x=False."""
         with pytest.raises(TwinYDataError, match="Dual X-axis plot requested but 'y2_data' given"):
             plot_with_dual_axes(
-                sample_x_data, sample_y_data, y2_data=sample_y_data, use_twin_x=False, axis_labels=["X1", "Y", "X2"]
+                sample_x_data, sample_y_data, y2_data=sample_y_data, use_twin_x=False, axis_labels=("X1", "Y", "X2")
             )
 
     def test_column_count_error_already_tested(self, tmp_path):
         """Verify ColumnCountError is already tested in TestPlotTwoColumnFile."""
-        # This is a reference test - the actual test is in TestPlotTwoColumnFile
         invalid_file = tmp_path / "invalid.csv"
         invalid_file.write_text("1,2,3\n4,5,6\n")
 
@@ -643,7 +643,6 @@ class TestCustomExceptions:
 
     def test_orientation_error_already_tested(self, sample_x_data, sample_y_data):
         """Verify OrientationError is already tested in TestTwoSubplots."""
-        # This is a reference test - the actual test is in TestTwoSubplots
         x_list = [sample_x_data, sample_x_data]
         y_list = [sample_y_data, sample_y_data * 2]
 
@@ -706,11 +705,11 @@ class TestCustomExceptions:
         from plotez.backend.error_handling import PlotError
 
         with pytest.raises(PlotError):
-            plot_with_dual_axes([], [1, 2, 3], axis_labels=["X", "Y1", "Y2"])
+            plot_with_dual_axes([], [1, 2, 3], axis_labels=("X", "Y1", "Y2"))
 
     def test_catch_axis_label_error_as_configuration_error(self, sample_x_data, sample_y_data):
         """Test that AxisLabelError can be caught as ConfigurationError."""
         from plotez.backend.error_handling import ConfigurationError
 
         with pytest.raises(ConfigurationError):
-            plot_with_dual_axes(sample_x_data, sample_y_data, axis_labels=["X", "Y"])
+            plot_with_dual_axes(sample_x_data, sample_y_data, axis_labels=("X", "Y"))


### PR DESCRIPTION
This pull request documents and clarifies several breaking changes and improvements in the v0.3.2 release, focusing on safer defaults, return types, and better parameter consistency. It also updates code examples and documentation to reflect these changes.

### API and Type Changes

* **Axes-only returns (Breaking):** All plotting functions now return only `Axes` (or tuples/arrays of `Axes` for multi-axis/grid functions), never `(Figure, Axes)`. The parent `Figure` is always accessible via `ax.get_figure()`. This is reflected in both documentation and updated examples. (`docs/CHANGELOG.md` [[1]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL8-R47) `docs/index.rst` [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L27-R29) `docs/quickstart.rst` [[3]](diffhunk://#diff-c9a9d6773bfb8f6a209256e8f1dc00db3eca97be188d9541607f55ca4f9744d1R137-R150) [[4]](diffhunk://#diff-c9a9d6773bfb8f6a209256e8f1dc00db3eca97be188d9541607f55ca4f9744d1L366-R379) `examples/rtd_images/RTD_E13_histogram.py` [[5]](diffhunk://#diff-578a1be7f06b31f4534d91b3b61101202eacc16f6c43e3e9d84bff1bc1cc7363L13-R13) [[6]](diffhunk://#diff-578a1be7f06b31f4534d91b3b61101202eacc16f6c43e3e9d84bff1bc1cc7363L22-R22) `examples/rtd_images/RTD_E14_density.py` [[7]](diffhunk://#diff-ed2077e58a7f3e994f56effe2b0427191ff901bc5ccdce172214e48e87f5854cL13-R13) [[8]](diffhunk://#diff-ed2077e58a7f3e994f56effe2b0427191ff901bc5ccdce172214e48e87f5854cL22-R22) `examples/rtd_images/RTD_E15_errorband_relative.py` [[9]](diffhunk://#diff-6a0836aec8883af9734941a2137302d3528b9d35d3a58218cdd10d392409feb7L16-R16) [[10]](diffhunk://#diff-6a0836aec8883af9734941a2137302d3528b9d35d3a58218cdd10d392409feb7L29-R29)
* **Type alias deprecation:** The `AxesFigReturn` type alias is deprecated in favor of `AxesReturn`, which now covers all return shapes. Documentation and Sphinx config are updated accordingly. (`docs/CHANGELOG.md` [[1]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL8-R47) `docs/api.rst` [[2]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68R197-R202) `docs/conf.py` [[3]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3R65-L67)

### Parameter and Function Behavior

* **Mutable default arguments fixed:** Parameters such as `data_labels`, `x_labels`, `y_labels`, `subplot_titles`, and `axis_labels` no longer use mutable list defaults. They now default to `None`, and a `DeprecationWarning` is emitted if a mutable `list` is passed (prefer `tuple`). Examples and docs are updated to show tuple usage. (`docs/CHANGELOG.md` [[1]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL8-R47) `examples/rtd_images/RTD_E8_two_subplots.py` [[2]](diffhunk://#diff-8af0d5a97bd7af2dda9c7c5a31fb6a5cbe9e96c5e3e1325e87fed25072c658c6L16-R18) `examples/ex_images/README_E3_dual_y_axis.py` [[3]](diffhunk://#diff-d1e1587a5381c2defe7a20c33ab6cb78b406ad1b98ea4cff96ee7767bff9c891L13-R13) `docs/quickstart.rst` [[4]](diffhunk://#diff-c9a9d6773bfb8f6a209256e8f1dc00db3eca97be188d9541607f55ca4f9744d1L284-R312)
* **Parameter renaming for consistency (Breaking):** `subplot_title` is renamed to `subplot_titles` in relevant functions for consistency. (`docs/CHANGELOG.md` [[1]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL8-R47) `docs/quickstart.rst` [[2]](diffhunk://#diff-c9a9d6773bfb8f6a209256e8f1dc00db3eca97be188d9541607f55ca4f9744d1R137-R150)

### Documentation and Example Updates

* **Docstring and warning clarifications:** Removed legacy references to the non-existent `auto_label` parameter, clarified error handling and warning usage, and explained the new deprecation warnings for mutable arguments. (`docs/CHANGELOG.md` [[1]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL8-R47) `docs/quickstart.rst` [[2]](diffhunk://#diff-c9a9d6773bfb8f6a209256e8f1dc00db3eca97be188d9541607f55ca4f9744d1L19-R20) [[3]](diffhunk://#diff-c9a9d6773bfb8f6a209256e8f1dc00db3eca97be188d9541607f55ca4f9744d1L247-L249) [[4]](diffhunk://#diff-c9a9d6773bfb8f6a209256e8f1dc00db3eca97be188d9541607f55ca4f9744d1L284-R312) [[5]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L61-R62)
* **Feature and version updates:** Updated features lists, version numbers, and coverage claims in the documentation to match the latest release. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L260-R260) `docs/index.rst` [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L27-R29) `docs/CHANGELOG.md` [[3]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL39-R72) [[4]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL118-R151)

### Type Annotation Improvements

* **Expanded type support:** Several config and wrapper functions now accept both `int` and `float` types (and lists thereof) for numeric parameters, and `HatchStyle` is used for hatching. (`src/plotez/backend/_wrappers.py` [[1]](diffhunk://#diff-8860d8931434237d71e3ed1cfac159539353111f4aaccd54ec87ececddc24939L23-R32) [[2]](diffhunk://#diff-8860d8931434237d71e3ed1cfac159539353111f4aaccd54ec87ececddc24939L84-R86) [[3]](diffhunk://#diff-8860d8931434237d71e3ed1cfac159539353111f4aaccd54ec87ececddc24939L206-R209) `src/plotez/backend/utilities.py` [[4]](diffhunk://#diff-8f574f782464d0aa2195f755b2e0eac7d4991b6b710a07888210768a6328db21L67-R75)

### Internal Cleanup

* **Removed dead code and unused warnings:** Eliminated the unused `_auto_handler` function and cleaned up related imports. (`docs/CHANGELOG.md` [[1]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bL8-R47) `src/plotez/backend/utilities.py` [[2]](diffhunk://#diff-8f574f782464d0aa2195f755b2e0eac7d4991b6b710a07888210768a6328db21L24-R29)

These changes improve type safety, consistency, and user control, but require updates to client code for breaking changes in return types and parameter names.